### PR TITLE
Rename 856 output file to sdr-purl-856s and append 856s instead of writing them out into separate files

### DIFF
--- a/bin/write_marc_record_test
+++ b/bin/write_marc_record_test
@@ -1,2 +1,2 @@
 #Do kerbose authentication here if it is required by the server
-echo $1 > $2
+echo $1 >> $2

--- a/lib/dor/update_marc_record_service.rb
+++ b/lib/dor/update_marc_record_service.rb
@@ -47,7 +47,7 @@ module Dor
       if symphony_record.nil? || symphony_record.length == 0 then
         return
       end
-      symphony_file_name = "#{Dor::Config.release.symphony_path}/sdr-purl-#{@druid_id}-#{Time.now.strftime('%Y%m%d%H%M%S')}"
+      symphony_file_name = "#{Dor::Config.release.symphony_path}/sdr-purl-856s"
       command = "#{Dor::Config.release.write_marc_script} '#{symphony_record}' #{symphony_file_name}"
       run_write_script(command)
     end


### PR DESCRIPTION
The symphony code expects only one file per day with all the 856s ready for symphony records.  The symphony script will, once a day, rename the file using the date retrieved and archive it.