### PR TITLE
The required tab after the catkey was being wiped out when the 856

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ config/environments/production.rb
 .DS_Store
 .ruby-version
 .ruby-gemset
+spec/fixtures

--- a/lib/dor/update_marc_record_service.rb
+++ b/lib/dor/update_marc_record_service.rb
@@ -48,7 +48,7 @@ module Dor
         return
       end
       symphony_file_name = "#{Dor::Config.release.symphony_path}/sdr-purl-856s"
-      command = "#{Dor::Config.release.write_marc_script} '#{symphony_record}' #{symphony_file_name}"
+      command = "#{Dor::Config.release.write_marc_script} \'#{symphony_record}\' #{symphony_file_name}"
       run_write_script(command)
     end
 
@@ -58,7 +58,7 @@ module Dor
         stderr_text = stderr.read
         
         if stdout_text.length > 0 || stderr_text.length > 0 then
-          raise "There was an error in writting marc_record file using the command #{command}\n#{stdout_text}\n#{stderr_text}"
+          raise "There was an error in writing marc_record file using the command #{command}\n#{stdout_text}\n#{stderr_text}"
         end
       end    
     end
@@ -67,9 +67,11 @@ module Dor
     # look in identityMetadata/otherId[@name='catkey']
     def ckey object
         catkey = nil
-        if object.datastreams["identityMetadata"].ng_xml then
-          node = object.identityMetadata.ng_xml.at_xpath("//identityMetadata/otherId[@name='catkey']")
-          catkey = node.content if !node.nil?
+        unless object.datastreams.nil? || object.datastreams["identityMetadata"].nil? then
+          if object.datastreams["identityMetadata"].ng_xml then
+            node = object.identityMetadata.ng_xml.at_xpath("//identityMetadata/otherId[@name='catkey']")
+            catkey = node.content if !node.nil?
+          end
         end
         catkey
     end
@@ -117,9 +119,11 @@ module Dor
     # @return [String] first filename
     def file_id
       id = nil
-      if @druid_obj.datastreams["contentMetadata"].ng_xml then
-        node = @druid_obj.datastreams["contentMetadata"].ng_xml.xpath('//contentMetadata/resource/file').first
-        id = node.attr("id").prepend("|xfile:") if !node.nil?
+      unless @druid_obj.datastreams.nil? || @druid_obj.datastreams["contentMetadata"].nil? then
+        if @druid_obj.datastreams["contentMetadata"].ng_xml then
+          node = @druid_obj.datastreams["contentMetadata"].ng_xml.xpath('//contentMetadata/resource/file').first
+          id = node.attr("id").prepend("|xfile:") if !node.nil?
+        end
       end
       id
     end

--- a/lib/dor/update_marc_record_service.rb
+++ b/lib/dor/update_marc_record_service.rb
@@ -58,7 +58,7 @@ module Dor
         stderr_text = stderr.read
         
         if stdout_text.length > 0 || stderr_text.length > 0 then
-          raise "There was an error in writing marc_record file using the command #{command}\n#{stdout_text}\n#{stderr_text}"
+          raise "Error in writing marc_record file using the command #{command}\n#{stdout_text}\n#{stderr_text}"
         end
       end    
     end

--- a/spec/lib/dor/update_marc_record_service_spec.rb
+++ b/spec/lib/dor/update_marc_record_service_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Dor::UpdateMarcRecordService do
   
   before :all do
-    @fixtures = "spec/fixtures/"
+    @fixtures = "./spec/fixtures"
   end
   
   describe ".push_symphony_record" do
@@ -98,35 +98,35 @@ describe Dor::UpdateMarcRecordService do
       d = Dor::Item.new 
       updater = Dor::UpdateMarcRecordService.new(d)
       updater.instance_variable_set(:@druid_id,"aa111aa1111")
-      Dor::Config.release.symphony_path = "#{@fixtures}/sdr_purl"
+      Dor::Config.release.symphony_path = "#{@fixtures}/sdr-purl"
       Dor::Config.release.write_marc_script = "bin/write_marc_record_test"
       updater.write_symphony_record "aaa"
       
-      expect(Dir.glob("#{@fixtures}/sdr_purl/sdr-purl-aa111aa1111-??????????????").empty?).to be false
+      expect(Dir.glob("#{@fixtures}/sdr-purl/sdr-purl-aa111aa1111-??????????????").empty?).to be false
    end    
     
     it "should do nothing if the symphony record is empty" do
       d = Dor::Item.new 
       updater = Dor::UpdateMarcRecordService.new(d)
       updater.instance_variable_set(:@druid_id,"aa111aa1111")
-      Dor::Config.release.symphony_path = "#{@fixtures}/sdr_purl"
+      Dor::Config.release.symphony_path = "#{@fixtures}/sdr-purl"
       updater.write_symphony_record ""
       
-      expect(Dir.glob("#{@fixtures}/sdr_purl/sdr-purl-aa111aa1111-??????????????").empty?).to be true
+      expect(Dir.glob("#{@fixtures}/sdr-purl/sdr-purl-aa111aa1111-??????????????").empty?).to be true
     end
   
     it "should do nothing if the symphony record is nil" do
       d = Dor::Item.new 
       updater = Dor::UpdateMarcRecordService.new(d)
       updater.instance_variable_set(:@druid_id,"aa111aa1111")
-      Dor::Config.release.symphony_path = "#{@fixtures}/sdr_purl"
+      Dor::Config.release.symphony_path = "#{@fixtures}/sdr-purl"
       updater.write_symphony_record ""
     
-      expect(Dir.glob("#{@fixtures}/sdr_purl/sdr-purl-aa111aa1111-??????????????").empty?).to be true
+      expect(Dir.glob("#{@fixtures}/sdr-purl/sdr-purl-aa111aa1111-??????????????").empty?).to be true
     end
   
     after :each do
-      FileUtils.rm_rf("#{@fixtures}/sdr_purl/.")
+      FileUtils.rm_rf("#{@fixtures}/sdr-purl/.")
     end
   end
 

--- a/spec/robots/update_marc_spec.rb
+++ b/spec/robots/update_marc_spec.rb
@@ -13,32 +13,36 @@ describe Robots::DorRepo::Release::UpdateMarc do
     @umr = Robots::DorRepo::Release::UpdateMarc.new 
   end  
 
-  it "runs the robot for a druid without a catkey and do nothing as a result" do
-    setup_release_item(@druid,:item)
-    umrs=Dor::UpdateMarcRecordService.new @dor_item
-    allow(Dor::Item).to receive(:find).with(@druid).and_return(@dor_item)
-    allow(umrs).to receive(:ckey).with(@dor_item).and_return(:nil)
-    expect(@dor_item).to receive(:datastreams).with(no_args)
-    expect(umrs).not_to receive(:push_symphony_record)
-    @umr.perform(@druid)
+  context "for a druid without a catkey" do
+    it 'does nothing' do
+      setup_release_item(@druid,:item)
+      umrs=Dor::UpdateMarcRecordService.new @dor_item
+      allow(Dor::Item).to receive(:find).with(@druid).and_return(@dor_item)
+      allow(umrs).to receive(:ckey).with(@dor_item).and_return(:nil)
+      expect(@dor_item).to receive(:datastreams).with(no_args)
+      expect(umrs).not_to receive(:push_symphony_record)
+      @umr.perform(@druid)
+    end
   end
-  
-  it "runs the robot for a druid with a catkey and execute the UpdateMarcRecordService push_symphony_record method" do
-    identityMetadataXML = Dor::IdentityMetadataDS.new
-    allow(identityMetadataXML).to receive_messages(
-      :ng_xml => Nokogiri::XML(build_identity_metadata_1)
-    )
-    dor_item=Dor::Item.new
-    allow(dor_item).to receive_messages(
-      :id=>@druid,
-      :datastreams => {"identityMetadata"=>identityMetadataXML}
-    )
-    umrs=Dor::UpdateMarcRecordService.new dor_item
-    allow(Dor::UpdateMarcRecordService).to receive_messages(:new=>umrs)
-    allow(Dor::Item).to receive(:find).with(@druid).and_return(dor_item)
-    allow(umrs).to receive(:ckey).with(dor_item).and_return('8832162')
-    expect(umrs).to receive(:push_symphony_record)
-    @umr.perform(@druid)
+
+  context "for a druid with a catkey" do
+    it "Executes the UpdateMarcRecordService push_symphony_record method" do
+      identityMetadataXML = Dor::IdentityMetadataDS.new
+      allow(identityMetadataXML).to receive_messages(
+        :ng_xml => Nokogiri::XML(build_identity_metadata_1)
+      )
+      dor_item=Dor::Item.new
+      allow(dor_item).to receive_messages(
+        :id=>@druid,
+        :datastreams => {"identityMetadata"=>identityMetadataXML}
+      )
+      umrs=Dor::UpdateMarcRecordService.new dor_item
+      allow(Dor::UpdateMarcRecordService).to receive_messages(:new=>umrs)
+      allow(Dor::Item).to receive(:find).with(@druid).and_return(dor_item)
+      allow(umrs).to receive(:ckey).with(dor_item).and_return('8832162')
+      expect(umrs).to receive(:push_symphony_record)
+      @umr.perform(@druid)
+    end
   end
 end
 

--- a/spec/robots/update_marc_spec.rb
+++ b/spec/robots/update_marc_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Robots::DorRepo::Release::UpdateMarc do
+
+  before :all do
+    Dor::Config.release.write_marc_script = 'bin/write_marc_record_test'
+    Dor::Config.release.symphony_path = './spec/fixtures/sdr-purl'
+    Dor::Config.release.purl_base_uri = "http://purl.stanford.edu"
+  end
+
+  before :each do
+    @druid='aa222cc3333'
+    @umr = Robots::DorRepo::Release::UpdateMarc.new 
+  end  
+
+  it "runs the robot for a druid without a catkey and do nothing as a result" do
+    setup_release_item(@druid,:item)
+    umrs=Dor::UpdateMarcRecordService.new @dor_item
+    allow(Dor::Item).to receive(:find).with(@druid).and_return(@dor_item)
+    allow(umrs).to receive(:ckey).with(@dor_item).and_return(:nil)
+    expect(@dor_item).to receive(:datastreams).with(no_args)
+    expect(umrs).not_to receive(:push_symphony_record)
+    @umr.perform(@druid)
+  end
+  
+  it "runs the robot for a druid with a catkey and execute the UpdateMarcRecordService push_symphony_record method" do
+    identityMetadataXML = Dor::IdentityMetadataDS.new
+    allow(identityMetadataXML).to receive_messages(
+      :ng_xml => Nokogiri::XML(build_identity_metadata_1)
+    )
+    dor_item=Dor::Item.new
+    allow(dor_item).to receive_messages(
+      :id=>@druid,
+      :datastreams => {"identityMetadata"=>identityMetadataXML}
+    )
+    umrs=Dor::UpdateMarcRecordService.new dor_item
+    allow(Dor::UpdateMarcRecordService).to receive_messages(:new=>umrs)
+    allow(Dor::Item).to receive(:find).with(@druid).and_return(dor_item)
+    allow(umrs).to receive(:ckey).with(dor_item).and_return('8832162')
+    expect(umrs).to receive(:push_symphony_record)
+    @umr.perform(@druid)
+  end
+end
+
+def build_identity_metadata_1
+      identityMetadataXML = '<identityMetadata>
+  <sourceId source="sul">36105216275185</sourceId>
+  <objectId>druid:bb987ch8177</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>A  new map of Africa</objectLabel>
+  <objectType>item</objectType>
+  <displayType>image</displayType>
+  <adminPolicy>druid:dd051ys2703</adminPolicy>
+  <otherId name="catkey">8832162</otherId>
+  <otherId name="uuid">ff3ce224-9ffb-11e3-aaf2-0050569b3c3c</otherId>
+  <tag>Process : Content Type : Map</tag>
+  <tag>Project : Batchelor Maps : Batch 1</tag>
+  <tag>LAB : MAPS</tag>
+  <tag>Registered By : dfuzzell</tag>
+  <tag>Remediated By : 4.15.4</tag>
+</identityMetadata>'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ def setup_release_item(druid,obj_type,item_members=nil)
   @dor_item=double(Dor::Item)
   allow(@dor_item).to receive_messages(
     :publish_metadata=>nil,
+    :id=>druid
       )
   allow(@release_item).to receive_messages(
       :druid=>druid,


### PR DESCRIPTION
 string was being written to the file because of the single quotes around #{symphony_record} in the building of the command string.  All that was required was that I escape out the single quotes when the command was being built.  Also fixed mis-spelling of writing and checking for nil datastreams instead of looking for ng_xml for nil datastreams.

@jmartin-sul 