### PR TITLE
use default ruby on machine and include cap in Gemfile

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -14,7 +14,7 @@ require 'capistrano/one_time_key'
 #   https://github.com/capistrano/bundler
 #   https://github.com/capistrano/rails
 #
-require 'capistrano/rvm'
+# require 'capistrano/rvm'
 # require 'capistrano/rbenv'
 # require 'capistrano/chruby'
 require 'capistrano/bundler'

--- a/Gemfile
+++ b/Gemfile
@@ -23,5 +23,7 @@ group :development do
     instance_eval(File.read(mygems))
   end
   gem 'yard'
+  gem 'capistrano', '~> 3.0'
+  gem 'capistrano-bundler', '~> 1.1'
   gem 'dlss-capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,9 @@ GEM
     capistrano-bundle_audit (0.0.5)
       bundler-audit
       capistrano (~> 3.0)
+    capistrano-bundler (1.1.4)
+      capistrano (~> 3.1)
+      sshkit (~> 1.2)
     capistrano-one_time_key (0.0.1)
       capistrano (~> 3.0)
     capistrano-releaseboard (0.0.1)
@@ -307,6 +310,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  capistrano (~> 3.0)
+  capistrano-bundler (~> 1.1)
   coveralls
   dlss-capistrano
   dor-fetcher

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,9 +1,6 @@
 # config valid only for Capistrano 3.1
 # lock '3.2.1'
 
-set :rvm_type, :system
-set :rvm_ruby_string, 'ruby-1.9.3-p484' # dor-services requires 1.9.3
-
 set :application, 'item-release'
 set :repo_url, 'https://github.com/sul-dlss/item-release.git'
 


### PR DESCRIPTION
This PR updates the capistrano dependencies and changes from 1.9.3 ruby to the default system ruby (which is 2.2.4 now).