### PR TITLE
Use relationships method to determine constituency instead of parsing RELS-EXT

### DIFF
--- a/lib/dor/update_marc_record_service.rb
+++ b/lib/dor/update_marc_record_service.rb
@@ -181,12 +181,9 @@ module Dor
     private
 
     def dor_items_for_constituents
-      return [] unless @druid_obj.datastreams
-      return [] unless @druid_obj.datastreams['RELS-EXT']
-      return [] unless @druid_obj.datastreams['RELS-EXT'].ng_xml
-      constituents = @druid_obj.datastreams['RELS-EXT'].ng_xml.xpath('//rdf:RDF/rdf:Description/fedora:isConstituentOf')
-      constituents.map do |cons|
-        cons_druid = cons.attr('rdf:resource').sub('info:fedora/', '')
+      return [] unless @druid_obj.relationships(:is_constituent_of)
+      @druid_obj.relationships(:is_constituent_of).map do |cons|
+        cons_druid = cons.sub('info:fedora/', '')
         Dor::Item.find(cons_druid)
       end
     end

--- a/spec/lib/dor/update_marc_record_service_spec.rb
+++ b/spec/lib/dor/update_marc_record_service_spec.rb
@@ -421,24 +421,13 @@ describe Dor::UpdateMarcRecordService do
   end
 
   describe 'dor_items_for_constituents' do
-    it 'should return empty array if no datastreams' do
-      item = double('item', id: '12345', datastreams: nil)
-      expect(Dor::UpdateMarcRecordService.new(item).send(:dor_items_for_constituents)).to eq([])
-    end
-    it 'should return empty array if no RELS-EXT datastreams' do
-      item = double('item', id: '12345', datastreams: {})
-      expect(Dor::UpdateMarcRecordService.new(item).send(:dor_items_for_constituents)).to eq([])
-    end
-    it 'should return empty array if no RELS-EXT ng_xml' do
-      item = double('item', id: '12345', datastreams: { 'RELS-EXT' => double('xml', ng_xml: nil) })
+    it 'should return empty array if no relationships' do
+      item = double('item', id: '12345', relationships: nil)
       expect(Dor::UpdateMarcRecordService.new(item).send(:dor_items_for_constituents)).to eq([])
     end
     it 'successfully determines constituent druid' do
-      rels_ext_xml = double(String, ng_xml: Nokogiri::XML(build_rels_ext))
-
-      item = double('item', id: '12345', datastreams: { 'RELS-EXT' => rels_ext_xml })
-
-      expect(Dor::Item).to receive(:find).with('druid:hj097bm8879')
+      item = double('item', id: '12345', relationships: ['info:fedora/druid:mb062dy1188'])
+      expect(Dor::Item).to receive(:find).with('druid:mb062dy1188')
       Dor::UpdateMarcRecordService.new(item).send(:dor_items_for_constituents)
     end
   end


### PR DESCRIPTION
I was able to get argo running on my laptop and figured out how to use the relationships method to get constitutency.  @jkeck