### PR TITLE
when items have no release tags, the update-marc step should still be…

### DIFF
--- a/config/environments/example.rb
+++ b/config/environments/example.rb
@@ -30,6 +30,16 @@ Dor::Config.configure do
     write_marc_script 'bin/write_marc_record_test'
   end
 
+  stacks do
+    document_cache_storage_root '/purl/document_cache'
+    document_cache_host 'purl.stanford.edu'
+    local_workspace_root '/dor/workspace'
+    local_stacks_root '/stacks'
+    local_document_cache_root '/purl/document_cache'
+    url 'https://stacks.stanford.edu'
+    iiif_profile 'http://iiif.io/api/image/2/level1.json'
+  end
+  
   dor do
     service_root 'https://USERNAME:PASSWORD@example.com/dor/v1'
   end

--- a/lib/dor/update_marc_record_service.rb
+++ b/lib/dor/update_marc_record_service.rb
@@ -172,7 +172,7 @@ module Dor
 
     def released_to_Searchworks
       rel = @druid_obj.released_for
-      rel['Searchworks']['release']
+      rel.blank? || rel['Searchworks'].blank? || rel['Searchworks']['release'].blank? ? false : rel['Searchworks']['release']
     end
 
     private

--- a/lib/dor/update_marc_record_service.rb
+++ b/lib/dor/update_marc_record_service.rb
@@ -171,8 +171,8 @@ module Dor
     end
 
     def released_to_Searchworks
-      rel = @druid_obj.released_for
-      rel.blank? || rel['Searchworks'].blank? || rel['Searchworks']['release'].blank? ? false : rel['Searchworks']['release']
+      rel = @druid_obj.released_for.transform_keys{ |key| key.to_s.upcase } # upcase all release tags to make the check case insensitive
+      rel.blank? || rel['SEARCHWORKS'].blank? || rel['SEARCHWORKS']['release'].blank? ? false : rel['SEARCHWORKS']['release']
     end
 
     private

--- a/spec/lib/dor/update_marc_record_service_spec.rb
+++ b/spec/lib/dor/update_marc_record_service_spec.rb
@@ -427,10 +427,33 @@ describe Dor::UpdateMarcRecordService do
       dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
       release_data = { 'Searchworks' => { 'release' => false } }
       allow(dor_item).to receive(:released_for).and_return(release_data)
-
       updater = Dor::UpdateMarcRecordService.new(dor_item)
       expect(updater.released_to_Searchworks).to be false
     end
+    it 'should return false if release_data tag has release to=SW but no specified release value' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = { 'Searchworks' => { 'bogus' => 'yup' } }
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be false
+    end   
+    it 'should return false if there are no release tags at all' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = {}
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be false
+    end    
+    it 'should return false if there are non searchworks related release tags' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = { 'Revs' => { 'release' => true } }
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be false
+    end      
   end
 
   describe 'dor_items_for_constituents' do

--- a/spec/lib/dor/update_marc_record_service_spec.rb
+++ b/spec/lib/dor/update_marc_record_service_spec.rb
@@ -414,7 +414,7 @@ describe Dor::UpdateMarcRecordService do
   end
 
   describe 'Released to Searchworks' do
-    it 'should return true if release_data tag has release to=SW and value is true' do
+    it 'should return true if release_data tag has release to=Searchworks and value is true' do
       identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_1))
       dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
       release_data = { 'Searchworks' => { 'release' => true } }
@@ -422,7 +422,23 @@ describe Dor::UpdateMarcRecordService do
       updater = Dor::UpdateMarcRecordService.new(dor_item)
       expect(updater.released_to_Searchworks).to be true
     end
-    it 'should return false if release_data tag has release to=SW and value is false' do
+    it 'should return true if release_data tag has release to=searchworks (all lowercase) and value is true' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_1))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = { 'searchworks' => { 'release' => true } }
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be true
+    end
+    it 'should return true if release_data tag has release to=SearchWorks (camcelcase) and value is true' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_1))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = { 'SearchWorks' => { 'release' => true } }
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be true
+    end
+    it 'should return false if release_data tag has release to=Searchworks and value is false' do
       identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
       dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
       release_data = { 'Searchworks' => { 'release' => false } }
@@ -430,7 +446,7 @@ describe Dor::UpdateMarcRecordService do
       updater = Dor::UpdateMarcRecordService.new(dor_item)
       expect(updater.released_to_Searchworks).to be false
     end
-    it 'should return false if release_data tag has release to=SW but no specified release value' do
+    it 'should return false if release_data tag has release to=Searchworks but no specified release value' do
       identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
       dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
       release_data = { 'Searchworks' => { 'bogus' => 'yup' } }


### PR DESCRIPTION
… able to run without erroring out

this bug fix has already been applied to the new way of doing this with dor-services-app: https://github.com/sul-dlss/dor-services-app/pull/31

this is just a way of getting the bug fix out to production now