### PR TITLE
switch dor find calls to remove reference to item

### DIFF
--- a/lib/dor/item.rb
+++ b/lib/dor/item.rb
@@ -12,7 +12,7 @@ module Dor::Release
     end
 
     def object
-      @fobj ||= Dor::Item.find(@druid)
+      @object ||= Dor.find(@druid)
     end
 
     def members
@@ -78,10 +78,10 @@ module Dor::Release
       with_retries(max_tries: Dor::Config.release.max_tries, base_sleep_seconds: Dor::Config.release.base_sleep_seconds, max_sleep_seconds: Dor::Config.release.max_sleep_seconds) do |_attempt|
         url = "#{Dor::Config.dor.service_root}/objects/#{@druid}/update_marc_record"
         response = RestClient.post url,{}
-        response.code  
+        response.code
       end
     end
-    
+
     def self.add_workflow_for_collection(druid)
       create_workflow(druid)
     end
@@ -95,7 +95,7 @@ module Dor::Release
 
       # initiate workflow
       with_retries(max_tries: Dor::Config.release.max_tries, base_sleep_seconds: Dor::Config.release.base_sleep_seconds, max_sleep_seconds: Dor::Config.release.max_sleep_seconds) do |_attempt|
-        obj = Dor::Item.find(druid)
+        obj = Dor.find(druid)
         obj.initialize_workflow(Dor::Config.release.workflow_name)
       end
     end

--- a/lib/dor/item.rb
+++ b/lib/dor/item.rb
@@ -96,7 +96,7 @@ module Dor::Release
       # initiate workflow
       with_retries(max_tries: Dor::Config.release.max_tries, base_sleep_seconds: Dor::Config.release.base_sleep_seconds, max_sleep_seconds: Dor::Config.release.max_sleep_seconds) do |_attempt|
         obj = Dor.find(druid)
-        obj.initialize_workflow(Dor::Config.release.workflow_name)
+        obj.create_workflow(Dor::Config.release.workflow_name)
       end
     end
 

--- a/spec/lib/dor/item_spec.rb
+++ b/spec/lib/dor/item_spec.rb
@@ -12,8 +12,8 @@ describe Dor::Release::Item do
     allow(@client).to receive(:get_collection).and_return(@response)
     @item.fetcher = @client
 
-    @dor_object = double(Dor::Item)
-    allow(Dor::Item).to receive(:find).and_return(@dor_object)
+    @dor_object = double(Dor)
+    allow(Dor).to receive(:find).and_return(@dor_object)
     allow(@dor_object).to receive(:initialize_workflow).and_return(true)
     allow(Dor::Config.workflow.client).to receive(:update_workflow_status).and_return(true)
   end
@@ -22,8 +22,8 @@ describe Dor::Release::Item do
     expect(@item.druid).to eq @druid
   end
 
-  it 'should call dor::item.find, but only once' do
-    expect(Dor::Item).to receive(:find).with(@druid).and_return(@dor_object).exactly(1).times
+  it 'should call Dor.find, but only once' do
+    expect(Dor).to receive(:find).with(@druid).and_return(@dor_object).exactly(1).times
     while @n < 3
       expect(@item.object).to eq @dor_object
       @n += 1
@@ -49,19 +49,19 @@ describe Dor::Release::Item do
   it 'should get the right value for sub_collections' do
     expect(@item.sub_collections).to eq @response['sets'] + @response['collections']
   end
-  
+
   it 'should add the workflow for a collection' do
-    expect(Dor::Item).to receive(:find).with(@druid).and_return(@dor_object).exactly(1).times
+    expect(Dor).to receive(:find).with(@druid).and_return(@dor_object).exactly(1).times
     expect(@dor_object).to receive(:initialize_workflow).with(Dor::Config.release.workflow_name).exactly(1).times
     Dor::Release::Item.add_workflow_for_collection(@druid)
   end
 
   it 'should add the workflow for an item' do
-    expect(Dor::Item).to receive(:find).with(@druid).and_return(@dor_object).exactly(1).times
+    expect(Dor).to receive(:find).with(@druid).and_return(@dor_object).exactly(1).times
     expect(@dor_object).to receive(:initialize_workflow).with(Dor::Config.release.workflow_name).exactly(1).times
     Dor::Release::Item.add_workflow_for_item(@druid)
   end
-  
+
   it 'should make a webservice call for updating_marc_records' do
     stub_request(:post, "https://example.com/dor/v1/objects/oo000oo0001/update_marc_record").
              with(headers: {'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Authorization' => 'Basic VVNFUk5BTUU6UEFTU1dPUkQ='}).

--- a/spec/lib/dor/item_spec.rb
+++ b/spec/lib/dor/item_spec.rb
@@ -14,7 +14,7 @@ describe Dor::Release::Item do
 
     @dor_object = double(Dor)
     allow(Dor).to receive(:find).and_return(@dor_object)
-    allow(@dor_object).to receive(:initialize_workflow).and_return(true)
+    allow(@dor_object).to receive(:create_workflow).and_return(true)
     allow(Dor::Config.workflow.client).to receive(:update_workflow_status).and_return(true)
   end
 
@@ -52,13 +52,13 @@ describe Dor::Release::Item do
 
   it 'should add the workflow for a collection' do
     expect(Dor).to receive(:find).with(@druid).and_return(@dor_object).exactly(1).times
-    expect(@dor_object).to receive(:initialize_workflow).with(Dor::Config.release.workflow_name).exactly(1).times
+    expect(@dor_object).to receive(:create_workflow).with(Dor::Config.release.workflow_name).exactly(1).times
     Dor::Release::Item.add_workflow_for_collection(@druid)
   end
 
   it 'should add the workflow for an item' do
     expect(Dor).to receive(:find).with(@druid).and_return(@dor_object).exactly(1).times
-    expect(@dor_object).to receive(:initialize_workflow).with(Dor::Config.release.workflow_name).exactly(1).times
+    expect(@dor_object).to receive(:create_workflow).with(Dor::Config.release.workflow_name).exactly(1).times
     Dor::Release::Item.add_workflow_for_item(@druid)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ end
 
 def setup_release_item(druid,obj_type,members)
   @release_item=Dor::Release::Item.new(:druid=>druid,:skip_heartbeat=>true)
-  @dor_item=double(Dor::Item)
+  @dor_item=double(Dor)
   allow(@dor_item).to receive_messages(
     :publish_metadata=>nil,
     :id=>druid


### PR DESCRIPTION
* use Dor.find instead of Dor::Item.find
* switch to "create_workflow" (replaces deprecated method)
* fix rubocop complaints about memoized methods and spacing