### PR TITLE
no need to load fedora objects just to create workflow

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,9 +22,9 @@ Dor::Config.configure do
   release do
     fetcher_root 'http://localhost:3000/'
     workflow_name 'releaseWF'
-    max_tries  5  # the number of attempts to retry service calls before failing
-    max_sleep_seconds   120  # max sleep seconds between tries
-    base_sleep_seconds  10   # base sleep seconds between tries    
+    max_tries  1  # the number of attempts to retry service calls before failing
+    max_sleep_seconds   1  # max sleep seconds between tries
+    base_sleep_seconds  1   # base sleep seconds between tries
   end
 
   stacks do

--- a/lib/dor/item.rb
+++ b/lib/dor/item.rb
@@ -93,10 +93,9 @@ module Dor::Release
     def self.create_workflow(druid)
       LyberCore::Log.debug "...adding workflow #{Dor::Config.release.workflow_name} for #{druid}"
 
-      # initiate workflow
+      # initiate workflow by making workflow service call
       with_retries(max_tries: Dor::Config.release.max_tries, base_sleep_seconds: Dor::Config.release.base_sleep_seconds, max_sleep_seconds: Dor::Config.release.max_sleep_seconds) do |_attempt|
-        obj = Dor.find(druid)
-        obj.create_workflow(Dor::Config.release.workflow_name)
+        Dor::Config.workflow.client.create_workflow('dor', druid, Dor::Config.release.workflow_name, Dor::WorkflowObject.initial_workflow(Dor::Config.release.workflow_name), {})
       end
     end
 

--- a/lib/dor/item.rb
+++ b/lib/dor/item.rb
@@ -95,7 +95,7 @@ module Dor::Release
 
       # initiate workflow by making workflow service call
       with_retries(max_tries: Dor::Config.release.max_tries, base_sleep_seconds: Dor::Config.release.base_sleep_seconds, max_sleep_seconds: Dor::Config.release.max_sleep_seconds) do |_attempt|
-        Dor::Config.workflow.client.create_workflow('dor', druid, Dor::Config.release.workflow_name, Dor::WorkflowObject.initial_workflow(Dor::Config.release.workflow_name), {})
+        Dor::Config.workflow.client.create_workflow(Dor::WorkflowObject.initial_repo(Dor::Config.release.workflow_name), druid, Dor::Config.release.workflow_name, Dor::WorkflowObject.initial_workflow(Dor::Config.release.workflow_name), {})
       end
     end
 

--- a/robots/release/release_members.rb
+++ b/robots/release/release_members.rb
@@ -24,19 +24,17 @@ module Robots       # Robot package
           case item.object_type
 
           when 'collection', 'set' # this is a collection or set
-            
+
             # check to see if all of the release tags for all targets are what=self, if so, we can skip adding workflow for all the members
             #   if at least one of the targets is *not* what=self, we will do it
             release_tags=item.object.get_newest_release_tag(item.object.release_tags) # get the latest release tag for each target
             if release_tags.collect {|_k,v| v['what']=='self'}.include?(false) # if there are any *non* what=self release tags in any targets, go ahead and add the workflow to the items
-              
+
               LyberCore::Log.debug "...fetching members of #{item.object_type}"
               if item.item_members # if there are any members, iterate through and add item workflows (which includes setting the first step to completed)
 
                 item.item_members.each do |item_member|
-                  with_retries(max_tries: Dor::Config.release.max_tries, base_sleep_seconds: Dor::Config.release.base_sleep_seconds, max_sleep_seconds: Dor::Config.release.max_sleep_seconds) do |_attempt|
-                    Dor::Release::Item.add_workflow_for_item(item_member['druid'])
-                  end
+                  Dor::Release::Item.add_workflow_for_item(item_member['druid'])
                 end
 
               else # no members found
@@ -48,9 +46,9 @@ module Robots       # Robot package
             else # all of the latest release tags are what=self or there are no release tags, so skip
 
               LyberCore::Log.debug "...all release tags are what=self for #{item.object_type}; skipping member workflows"
-              
+
             end # end check for what=self release tags
-            
+
             if item.sub_collections # if there are any sub-collections, iterate through and add collection workflows
 
               item.sub_collections.each do |sub_collection|

--- a/spec/lib/dor/item_spec.rb
+++ b/spec/lib/dor/item_spec.rb
@@ -14,8 +14,7 @@ describe Dor::Release::Item do
 
     @dor_object = double(Dor)
     allow(Dor).to receive(:find).and_return(@dor_object)
-    allow(@dor_object).to receive(:create_workflow).and_return(true)
-    allow(Dor::Config.workflow.client).to receive(:update_workflow_status).and_return(true)
+    allow(Dor::WorkflowObject).to receive(:initial_workflow).and_return(true)
   end
 
   it 'should initialize' do
@@ -51,14 +50,12 @@ describe Dor::Release::Item do
   end
 
   it 'should add the workflow for a collection' do
-    expect(Dor).to receive(:find).with(@druid).and_return(@dor_object).exactly(1).times
-    expect(@dor_object).to receive(:create_workflow).with(Dor::Config.release.workflow_name).exactly(1).times
+    expect(Dor::Config.workflow.client).to receive(:create_workflow).exactly(1).times
     Dor::Release::Item.add_workflow_for_collection(@druid)
   end
 
   it 'should add the workflow for an item' do
-    expect(Dor).to receive(:find).with(@druid).and_return(@dor_object).exactly(1).times
-    expect(@dor_object).to receive(:create_workflow).with(Dor::Config.release.workflow_name).exactly(1).times
+    expect(Dor::Config.workflow.client).to receive(:create_workflow).exactly(1).times
     Dor::Release::Item.add_workflow_for_item(@druid)
   end
 

--- a/spec/lib/dor/item_spec.rb
+++ b/spec/lib/dor/item_spec.rb
@@ -14,7 +14,8 @@ describe Dor::Release::Item do
 
     @dor_object = double(Dor)
     allow(Dor).to receive(:find).and_return(@dor_object)
-    allow(Dor::WorkflowObject).to receive(:initial_workflow).and_return(true)
+    allow(Dor::WorkflowObject).to receive(:initial_workflow).with(Dor::Config.release.workflow_name).and_return(true)
+    allow(Dor::WorkflowObject).to receive(:initial_repo).with(Dor::Config.release.workflow_name).and_return(true)
   end
 
   it 'should initialize' do
@@ -50,12 +51,12 @@ describe Dor::Release::Item do
   end
 
   it 'should add the workflow for a collection' do
-    expect(Dor::Config.workflow.client).to receive(:create_workflow).with('dor', @druid, Dor::Config.release.workflow_name, Dor::WorkflowObject.initial_workflow(Dor::Config.release.workflow_name), {}).exactly(1).times
+    expect(Dor::Config.workflow.client).to receive(:create_workflow).with(Dor::WorkflowObject.initial_repo(Dor::Config.release.workflow_name), @druid, Dor::Config.release.workflow_name, Dor::WorkflowObject.initial_workflow(Dor::Config.release.workflow_name), {}).exactly(1).times
     Dor::Release::Item.add_workflow_for_collection(@druid)
   end
 
   it 'should add the workflow for an item' do
-    expect(Dor::Config.workflow.client).to receive(:create_workflow).with('dor', @druid, Dor::Config.release.workflow_name, Dor::WorkflowObject.initial_workflow(Dor::Config.release.workflow_name), {}).exactly(1).times
+    expect(Dor::Config.workflow.client).to receive(:create_workflow).with(Dor::WorkflowObject.initial_repo(Dor::Config.release.workflow_name), @druid, Dor::Config.release.workflow_name, Dor::WorkflowObject.initial_workflow(Dor::Config.release.workflow_name), {}).exactly(1).times
     Dor::Release::Item.add_workflow_for_item(@druid)
   end
 

--- a/spec/lib/dor/item_spec.rb
+++ b/spec/lib/dor/item_spec.rb
@@ -50,12 +50,12 @@ describe Dor::Release::Item do
   end
 
   it 'should add the workflow for a collection' do
-    expect(Dor::Config.workflow.client).to receive(:create_workflow).exactly(1).times
+    expect(Dor::Config.workflow.client).to receive(:create_workflow).with('dor', @druid, Dor::Config.release.workflow_name, Dor::WorkflowObject.initial_workflow(Dor::Config.release.workflow_name), {}).exactly(1).times
     Dor::Release::Item.add_workflow_for_collection(@druid)
   end
 
   it 'should add the workflow for an item' do
-    expect(Dor::Config.workflow.client).to receive(:create_workflow).exactly(1).times
+    expect(Dor::Config.workflow.client).to receive(:create_workflow).with('dor', @druid, Dor::Config.release.workflow_name, Dor::WorkflowObject.initial_workflow(Dor::Config.release.workflow_name), {}).exactly(1).times
     Dor::Release::Item.add_workflow_for_item(@druid)
   end
 


### PR DESCRIPTION
* call workflow service directly instead of loading objects each time
* eliminate unnecessary retries (method being called already has retries)
* minimize retries in test so we fail quickly if a test fails
* whitespace cleanup