### PR TITLE
Tell HoundCI not to review Ruby code

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,2 @@
 ruby:
-  config_file: .rubocop.yml
+  enabled: false


### PR DESCRIPTION
We already use RuboCop for this and should not need to double up.